### PR TITLE
Adding spellcheck attribute in trix_editor_tag method

### DIFF
--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -12,6 +12,7 @@ module TrixEditorHelper
 
     attributes[:autofocus] = true if options[:autofocus]
     attributes[:placeholder] = options[:placeholder] if options[:placeholder]
+    attributes[:spellcheck] = options[:spellcheck] if options[:spellcheck]
     attributes[:input] = options[:input] || "trix_input_#{TrixEditorHelper.id += 1}"
     attributes[:toolbar] = options[:toolbar] if options[:toolbar]
 


### PR DESCRIPTION
This fixes issue #13

Example with spellcheck option:
Any place where you would like to use the Trix editor in your forms with a spellchecking attribute, now you can just use the trix_editor helper with the spellchecking options as follows:

`<%= f.trix_editor :content, spellcheck: "false" %>`