### PR TITLE
Require action_view and spec_helper for tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'trix'
 require 'action_controller'
+require 'action_view'
 require 'rspec/rails'
 require 'rspec/active_model/mocks'

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'trix/form'
 
 describe TrixEditorHelper, type: :helper do


### PR DESCRIPTION
* On my rails 4.2.6 tests were not passing I had to require action_view
  in spec_helper for them to pass. Here is error that I get without picking action_view in spec_helper:
<img width="1248" alt="screen shot 2016-03-19 at 10 40 35" src="https://cloud.githubusercontent.com/assets/7427365/13897818/4737cfea-edbf-11e5-9958-066e99e0fa35.png">

This discussion on rails issues helped me for issue:
https://github.com/rails/rails/issues/17936

* Also, added require spec_helper to `trix_editor_helper_spec.rb`, so
  we could test him separately in isolation

ps
Here is my Gemfile.lock
https://gist.github.com/dixpac/0e30cf2cbfc8cf91f774