### PR TITLE
Add tabindex attribute for trix_editor_tag

### DIFF
--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -10,12 +10,11 @@ module TrixEditorHelper
 
     css_class = Array.wrap(options[:class]).join(' ')
     attributes = { class: "formatted_content trix-content #{css_class}".squish }
-
     attributes[:autofocus] = true if options[:autofocus]
-    attributes[:placeholder] = options[:placeholder] if options[:placeholder]
-    attributes[:spellcheck] = options[:spellcheck] if options[:spellcheck]
     attributes[:input] = options[:input] || "trix_input_#{TrixEditorHelper.id += 1}"
-    attributes[:toolbar] = options[:toolbar] if options[:toolbar]
+
+    valid_html_options = [:placeholder, :spellcheck, :toolbar, :tabindex]
+    attributes.merge!(options.slice(*valid_html_options))
 
     editor_tag = content_tag('trix-editor', '', attributes)
     input_tag = hidden_field_tag(name, value, id: attributes[:input])

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -33,5 +33,35 @@ describe TrixEditorHelper, type: :helper do
         match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
+
+    it 'accepts spellcheck option' do
+      expect(helper.trix_editor_tag('text', nil, spellcheck: true)).to(
+        include('spellcheck="true"')
+      )
+    end
+
+    it 'accepts placeholder option' do
+      expect(helper.trix_editor_tag('text', nil, placeholder: 'Sample text')).to(
+        include('placeholder="Sample text"')
+      )
+    end
+
+    it 'accepts toolbar option' do
+      expect(helper.trix_editor_tag('text', nil, toolbar: true)).to(
+        include('toolbar="true"')
+      )
+    end
+
+    it 'accepts tabindex option' do
+      expect(helper.trix_editor_tag('text', nil, tabindex: 1)).to(
+        include('tabindex="1"')
+      )
+    end
+
+    it 'ignores non-whitelisted options' do
+      expect(helper.trix_editor_tag('text', nil, non_existing_option: 2)).not_to(
+        include('non_existing_option="2"')
+      )
+    end
   end
 end


### PR DESCRIPTION
I have added tabindex attribute for trix_editor_tag. 

I found it quite useful for a project that I am currently working on and maybe this would be helpful for others as well. This is helpful when trix editor field is not the first on the page (e.g. there is a title, tags or categories fields above) and a user wants to tab from the above fields to trix editor field. Without tabindex, tab goes through all the editor icons first which is not very user-friendly.

With this change `trix_editor` accepts `tagindex` attribute similarly as other attributes, e.g. `tabindex: 1`

Please let me know what you think.
