### PR TITLE
Support provided value in form helper

### DIFF
--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -36,7 +36,7 @@ module ActionView
           options = @options.stringify_keys
           add_default_name_and_id(options)
           options['input'] ||= dom_id(object, [options['id'], :trix_input].compact.join('_'))
-          trix_editor_tag(options.delete('name'), value_before_type_cast(object), options)
+          trix_editor_tag(options.delete('name'), (options['value'] || value_before_type_cast(object)), options)
         end
       end
     end

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -9,6 +9,20 @@ describe TrixEditorHelper, type: :helper do
       assign(:blog, blog)
       expect(helper.trix_editor(:blog, :text)).to include('trix-editor')
     end
+
+    it 'uses value from object' do
+      blog = mock_model('Blog', text: 'my_original_value')
+
+      assign(:blog, blog)
+      expect(helper.trix_editor(:blog, :text)).to include('my_original_value')
+    end
+
+    it 'uses a provided value instead of value from object' do
+      blog = mock_model('Blog', text: 'my_original_value')
+
+      assign(:blog, blog)
+      expect(helper.trix_editor(:blog, :text, value: "my_provided_value")).to include('my_provided_value')
+    end
   end
 
   describe '#trix_editor_tag' do


### PR DESCRIPTION
Some of my form fields have default values, like so:

> = f.trix_editor :intro, value: ((@business.intro.present? && @business.intro) || "Default intro")

In this case, I want to pass the value of the form field explicitly. Rails' default form helpers allow this, but it did not work with the `trix_editor` helper. This PR enables it.

I'm not sure if more has to be done to support Formtastic.