### PR TITLE
Adds trix-content class

### DIFF
--- a/lib/formtastic/inputs/trix_editor_input.rb
+++ b/lib/formtastic/inputs/trix_editor_input.rb
@@ -2,8 +2,10 @@ class TrixEditorInput < Formtastic::Inputs::StringInput
   def to_html
     input_wrapping do
       editor_tag_params = {
-        input: input_html_options[:id]
+        input: input_html_options[:id],
+        class: 'trix-content'
       }
+
       editor_tag = template.content_tag('trix-editor', '', editor_tag_params)
       hidden_field = builder.hidden_field(method, input_html_options)
 

--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -9,7 +9,7 @@ module TrixEditorHelper
     options.symbolize_keys!
 
     css_class = Array.wrap(options[:class]).join(' ')
-    attributes = { class: "formatted_content #{css_class}".squish }
+    attributes = { class: "formatted_content trix-content #{css_class}".squish }
 
     attributes[:autofocus] = true if options[:autofocus]
     attributes[:placeholder] = options[:placeholder] if options[:placeholder]

--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,7 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        editor_tag = template.content_tag('trix-editor', '', input: input_class)
+        editor_tag = template.content_tag('trix-editor', '', input: input_class, class: 'trix-content')
         hidden_field = @builder.hidden_field(attribute_name, input_html_options)
 
         template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')

--- a/spec/formtastic_integration_spec.rb
+++ b/spec/formtastic_integration_spec.rb
@@ -23,5 +23,8 @@ describe TrixEditorInput, type: :view do
 
     # Output HTML contains the editor tag
     assert_select 'trix-editor[input="post_body"]'
+
+    # Output editor tag has trix-content class
+    assert_select 'trix-editor.trix-content'
   end
 end

--- a/spec/simple_form/simple_form_integration_spec.rb
+++ b/spec/simple_form/simple_form_integration_spec.rb
@@ -21,4 +21,8 @@ describe Trix::SimpleForm::TrixEditorInput, type: :view do
   it 'outputs HTML containing the trix editor tag' do
     assert_select 'trix-editor[input="post_body"]'
   end
+
+  it 'outputs HTML containing the trix editor tag with a trix-content class' do
+    assert_select 'trix-editor.trix-content'
+  end
 end

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -18,19 +18,19 @@ describe TrixEditorHelper, type: :helper do
 
     it 'accepts a string class option' do
       expect(helper.trix_editor_tag('text', nil, class: 'one two three')).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
 
     it 'accepts a simple array class option' do
       expect(helper.trix_editor_tag('text', nil, class: %w[one two three])).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
 
     it 'accepts a mixed array class option' do
       expect(helper.trix_editor_tag('text', nil, class: ['one two', :three])).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
   end


### PR DESCRIPTION
As stated on https://github.com/basecamp/trix#styling-formatted-content:

To ensure what you see when you edit is what you see when you save, use a CSS class name to scope styles for Trix formatted content. Apply this class name to your <trix-editor> element, and to a containing element when you render stored Trix content for display in your application.

```html
<trix-editor class="trix-content"></trix-editor>
```