### PR TITLE
Allow use of trix directly with trix_editor_tag by injecting into ActionView::Base

### DIFF
--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -23,6 +23,8 @@ module TrixEditorHelper
   end
 end
 
+ActionView::Base.send :include, TrixEditorHelper
+
 module ActionView
   module Helpers
     include TrixEditorHelper


### PR DESCRIPTION
This feels a bit icky to me and like I'm not doing it the true "rails way", but it does work on my project. Any suggestions welcome!