### PR TITLE
Additional attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you are using the [Formtastic](https://github.com/justinfrench/formtastic) ge
 f.input :body, as: :trix_editor
 ```
 
+Attributes `autofocus` and `placeholder` set using `:input_html` are passed through to the trix-editor-tag.
+
 ## Trix
 
 For the official Trix Github repository, go

--- a/lib/formtastic/inputs/trix_editor_input.rb
+++ b/lib/formtastic/inputs/trix_editor_input.rb
@@ -2,8 +2,10 @@ class TrixEditorInput < Formtastic::Inputs::StringInput
   def to_html
     input_wrapping do
       editor_tag_params = {
-        input: input_html_options[:id]
+        input: input_html_options[:id],
+        class: 'trix-content'
       }
+
       editor_tag = template.content_tag('trix-editor', '', editor_tag_params)
       hidden_field = builder.hidden_field(method, input_html_options)
 

--- a/lib/formtastic/inputs/trix_editor_input.rb
+++ b/lib/formtastic/inputs/trix_editor_input.rb
@@ -1,17 +1,32 @@
 class TrixEditorInput < Formtastic::Inputs::StringInput
   def to_html
     input_wrapping do
-      editor_tag_params = {
-        input: input_html_options[:id],
-        class: 'trix-content'
-      }
+      construct_editor_tag_params
 
-      editor_tag = template.content_tag('trix-editor', '', editor_tag_params)
+      editor_tag = template.content_tag('trix-editor', '', @editor_tag_params)
       hidden_field = builder.hidden_field(method, input_html_options)
 
       editor = template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')
 
       label_html + editor
     end
+  end
+
+  # In Formtastic::Inputs::Base::Html#input_html_options is always generated so we cannot .delete on it
+  #
+  # This implementation calls the original only once
+  def input_html_options
+    @input_html_options ||= super
+  end
+
+  # Returns params specifically for the trix-editor-tag and moves options autofocus and placeholder
+  # from the input_html_options to here
+  def construct_editor_tag_params
+    @editor_tag_params ||= {
+      input: input_html_options[:id],
+      class: 'trix-content',
+      autofocus: input_html_options.delete(:autofocus),
+      placeholder: input_html_options.delete(:placeholder)
+    }
   end
 end

--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -9,7 +9,7 @@ module TrixEditorHelper
     options.symbolize_keys!
 
     css_class = Array.wrap(options[:class]).join(' ')
-    attributes = { class: "formatted_content #{css_class}".squish }
+    attributes = { class: "formatted_content trix-content #{css_class}".squish }
 
     attributes[:autofocus] = true if options[:autofocus]
     attributes[:placeholder] = options[:placeholder] if options[:placeholder]

--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,14 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        editor_tag = template.content_tag('trix-editor', '', input: input_class, class: 'trix-content')
+        editor_tag_params = {
+          input: input_class,
+          class: 'trix-content',
+          autofocus: input_html_options.delete(:autofocus),
+          placeholder: input_html_options.delete(:placeholder)
+        }
+
+        editor_tag = template.content_tag('trix-editor', '', editor_tag_params)
         hidden_field = @builder.hidden_field(attribute_name, input_html_options)
 
         template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')

--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,7 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        editor_tag = template.content_tag('trix-editor', '', input: input_class)
+        editor_tag = template.content_tag('trix-editor', '', input: input_class, class: 'trix-content')
         hidden_field = @builder.hidden_field(attribute_name, input_html_options)
 
         template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')

--- a/spec/formtastic_integration_spec.rb
+++ b/spec/formtastic_integration_spec.rb
@@ -27,4 +27,29 @@ describe TrixEditorInput, type: :view do
     # Output editor tag has trix-content class
     assert_select 'trix-editor.trix-content'
   end
+
+  context 'input_html options' do
+    let(:form) do
+      semantic_form_for(post) do |f|
+        f.input :body,
+                as: :trix_editor,
+                input_html: { autofocus: true, placeholder: 'my text', data: { some_stuff: 1 } }
+      end
+    end
+
+    it 'sets autofocus on the trix-editor-tag' do
+      assert_select 'trix-editor[autofocus="autofocus"]'
+      assert_select 'input[type="hidden"][autofocus="autofocus"]', false
+    end
+
+    it 'sets placeholder on the trix-editor-tag' do
+      assert_select 'trix-editor[placeholder="my text"]'
+      assert_select 'input[type="hidden"][placeholder="placeholder"]', false
+    end
+
+    it 'sets other options on the hidden input' do
+      assert_select 'input[type="hidden"][data-some-stuff="1"]'
+      assert_select 'trix-editor[data-some-stuff="1"]', false
+    end
+  end
 end

--- a/spec/formtastic_integration_spec.rb
+++ b/spec/formtastic_integration_spec.rb
@@ -23,5 +23,8 @@ describe TrixEditorInput, type: :view do
 
     # Output HTML contains the editor tag
     assert_select 'trix-editor[input="post_body"]'
+
+    # Output editor tag has trix-content class
+    assert_select 'trix-editor.trix-content'
   end
 end

--- a/spec/simple_form/simple_form_integration_spec.rb
+++ b/spec/simple_form/simple_form_integration_spec.rb
@@ -21,4 +21,8 @@ describe Trix::SimpleForm::TrixEditorInput, type: :view do
   it 'outputs HTML containing the trix editor tag' do
     assert_select 'trix-editor[input="post_body"]'
   end
+
+  it 'outputs HTML containing the trix editor tag with a trix-content class' do
+    assert_select 'trix-editor.trix-content'
+  end
 end

--- a/spec/simple_form/simple_form_integration_spec.rb
+++ b/spec/simple_form/simple_form_integration_spec.rb
@@ -25,4 +25,29 @@ describe Trix::SimpleForm::TrixEditorInput, type: :view do
   it 'outputs HTML containing the trix editor tag with a trix-content class' do
     assert_select 'trix-editor.trix-content'
   end
+
+  context 'input_html options' do
+    let(:form) do
+      simple_form_for(post, url: 'some-url') do |f|
+        f.input :body,
+                as: :trix_editor,
+                input_html: { autofocus: true, placeholder: 'my text', data: { some_stuff: 1 } }
+      end
+    end
+
+    it 'sets autofocus on the trix-editor-tag' do
+      assert_select 'trix-editor[autofocus="autofocus"]'
+      assert_select 'input[type="hidden"][autofocus="autofocus"]', false
+    end
+
+    it 'sets placeholder on the trix-editor-tag' do
+      assert_select 'trix-editor[placeholder="my text"]'
+      assert_select 'input[type="hidden"][placeholder="placeholder"]', false
+    end
+
+    it 'sets other options on the hidden input' do
+      assert_select 'input[type="hidden"][data-some-stuff="1"]'
+      assert_select 'trix-editor[data-some-stuff="1"]', false
+    end
+  end
 end

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -33,5 +33,17 @@ describe TrixEditorHelper, type: :helper do
         match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
+
+    it 'accepts an autofocus option' do
+      expect(helper.trix_editor_tag('text', nil, autofocus: true)).to(
+        match(/<trix-editor.*autofocus="autofocus"/)
+      )
+    end
+
+    it 'accepts a placeholder option' do
+      expect(helper.trix_editor_tag('text', nil, placeholder: 'my text')).to(
+        match(/<trix-editor.*placeholder="my text"/)
+      )
+    end
   end
 end

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -18,19 +18,19 @@ describe TrixEditorHelper, type: :helper do
 
     it 'accepts a string class option' do
       expect(helper.trix_editor_tag('text', nil, class: 'one two three')).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
 
     it 'accepts a simple array class option' do
       expect(helper.trix_editor_tag('text', nil, class: %w[one two three])).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
 
     it 'accepts a mixed array class option' do
       expect(helper.trix_editor_tag('text', nil, class: ['one two', :three])).to(
-        match(/<trix-editor class="formatted_content one two three"/)
+        match(/<trix-editor class="formatted_content trix-content one two three"/)
       )
     end
   end


### PR DESCRIPTION
See https://github.com/maclover7/trix/issues/20 and https://github.com/maclover7/trix/issues/24

The readme of Trix only states autofocus and placeholder so only those two are moved from the hidden input to the trix-editor-tag.

Next do this we could allow a :editor_input_html next to :input_html to set any arbitrary option?