### PR TITLE
Output hidden input element before trix element

### DIFF
--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -20,7 +20,7 @@ module TrixEditorHelper
     editor_tag = content_tag('trix-editor', '', attributes)
     input_tag = hidden_field_tag(name, value, id: attributes[:input])
 
-    editor_tag + input_tag
+    input_tag + editor_tag
   end
 end
 


### PR DESCRIPTION
I ran into an issue where `<trix-editor>` would occasionally render an empty editor, even though the associated hidden `<input>` was populated with content.

(This only happened in Google Chrome and when there was a large amount of data to load into the editor. And, it only happened ~10% of the time).

After much investigating, it _seems_ the cause is that the editor tag is output _before_ the input tag.
 The Trix [documentation for populating With Stored Content](https://github.com/basecamp/trix/tree/0.10.2#populating-with-stored-content) places the hidden input _before_ the trix element, and @javan [confirmed this is the recommended approach](https://github.com/basecamp/trix/issues/254#issuecomment-321814353).

This pull request simply swaps the order that the tags are output to adhere to Trix's recommendation.