### PR TITLE
Use either the id from input_html or rails default

### DIFF
--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,8 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        editor_tag = template.content_tag('trix-editor', '', input: input_class, class: 'trix-content')
+        trix_input = input_html_options[:id] || input_class
+        editor_tag = template.content_tag('trix-editor', '', input: trix_input, class: 'trix-content')
         hidden_field = @builder.hidden_field(attribute_name, input_html_options)
 
         template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')

--- a/spec/simple_form/simple_form_integration_spec.rb
+++ b/spec/simple_form/simple_form_integration_spec.rb
@@ -25,4 +25,16 @@ describe Trix::SimpleForm::TrixEditorInput, type: :view do
   it 'outputs HTML containing the trix editor tag with a trix-content class' do
     assert_select 'trix-editor.trix-content'
   end
+
+  context 'changing html_options' do
+    let(:form) do
+      simple_form_for(post, url: 'some-url') do |f|
+        f.input(:body, as: :trix_editor, input_html: { id: 'custom' })
+      end
+    end
+
+    it 'outputs HTML containing the trix editor pointing to the correct input id' do
+      assert_select 'trix-editor[input="custom"]'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #41. It was happening due to having at least two inputs with the same id making trix to always get the first one.

One work around is to set different html `id`s for each hidden input `input_html` but the  trix wrapper won't set the input correctly. This PR fixes this issue.