### PR TITLE
Allow arbitray options to trix_editor_tag (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ forms, just use the `trix_editor` helper:
 f.trix_editor :body
 ```
 
+Any options passed to the `trix_editor` will render as HTML attributes on the `trix-editor` tag. For example:
+
+```ruby
+f.trix_editor :body, autofocus: true, data: { coffee: :delicious }
+```
+
+will render something like:
+
+```html
+<trix-editor autofocus="true" data-coffee="delicious">
+```
+
 If you are using the [Formtastic](https://github.com/justinfrench/formtastic) gem or the [Simple Form](https://github.com/plataformatec/simple_form) gem, you can do this:
 
 ```ruby

--- a/lib/trix/form.rb
+++ b/lib/trix/form.rb
@@ -8,13 +8,11 @@ module TrixEditorHelper
   def trix_editor_tag(name, value = nil, options = {})
     options.symbolize_keys!
 
-    css_class = Array.wrap(options[:class]).join(' ')
-    attributes = { class: "formatted_content trix-content #{css_class}".squish }
-    attributes[:autofocus] = true if options[:autofocus]
-    attributes[:input] = options[:input] || "trix_input_#{TrixEditorHelper.id += 1}"
-
-    valid_html_options = [:placeholder, :spellcheck, :toolbar, :tabindex]
-    attributes.merge!(options.slice(*valid_html_options))
+    css_class = Array.wrap(options.delete(:class)).join(' ')
+    attributes = {
+      class: "formatted_content trix-content #{css_class}".squish,
+      input: "trix_input_#{TrixEditorHelper.id += 1}"
+    }.merge(options)
 
     editor_tag = content_tag('trix-editor', '', attributes)
     input_tag = hidden_field_tag(name, value, id: attributes[:input])

--- a/spec/trix_editor_helper_spec.rb
+++ b/spec/trix_editor_helper_spec.rb
@@ -16,6 +16,24 @@ describe TrixEditorHelper, type: :helper do
       expect(helper.trix_editor_tag('text')).to include('trix-editor')
     end
 
+    it 'has a default input' do
+      expect(helper.trix_editor_tag('text', nil)).to(
+        include("input=\"trix_input_#{TrixEditorHelper.id}\"")
+      )
+    end
+
+    it 'accepts a custom input' do
+      expect(helper.trix_editor_tag('text', nil, input: 'my-input')).to(
+        include('input="my-input"')
+      )
+    end
+
+    it 'has default classes' do
+      expect(helper.trix_editor_tag('text', nil)).to(
+        match(/<trix-editor class="formatted_content trix-content"/)
+      )
+    end
+
     it 'accepts a string class option' do
       expect(helper.trix_editor_tag('text', nil, class: 'one two three')).to(
         match(/<trix-editor class="formatted_content trix-content one two three"/)
@@ -58,9 +76,15 @@ describe TrixEditorHelper, type: :helper do
       )
     end
 
-    it 'ignores non-whitelisted options' do
-      expect(helper.trix_editor_tag('text', nil, non_existing_option: 2)).not_to(
-        include('non_existing_option="2"')
+    it 'accepts data options' do
+      expect(helper.trix_editor_tag('text', nil, data: { coffee: :delicious })).to(
+        include('data-coffee="delicious"')
+      )
+    end
+
+    it 'accepts non-standard options' do
+      expect(helper.trix_editor_tag('text', nil, non_standard_option: 2)).to(
+        include('non_standard_option="2"')
       )
     end
   end


### PR DESCRIPTION
This pull-request implements the enhancement proposed in #20.

HTML options passed to `trix_editor_tag` should be passed directly to `content_tag` with as little modification as possible. There is no need for `trix_editor_tag` to validate or whitelist which attributes should be passed along. Users should expect `trix_editor_tag` to follow the same API  as [`content_tag`](http://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag). 